### PR TITLE
Disable Iceberg models so Python models can build locally

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -43,9 +43,9 @@ models:
       +materialized: table
       +catalog_name: snowflake_cld
       zendesk:
-        +enabled: true
+        +enabled: false
       zendesk_2:
-        +enabled: true
+        +enabled: false
 
 quoting:
   database: false


### PR DESCRIPTION
## Problem

`dbt run --select python_test_model` failed before any node started:

```
004510 (42601): SQL compilation error: Invalid identifier ETLEAP_DBT_PR_XX.
Only lowercase and double-quoted identifier names are allowed for case
insensitive catalog like AWS Glue, Unity etc. in catalog-linked databases.
```

The Python model was never at fault. dbt's relation-cache warm-up lists **every schema in the manifest**, not just the schemas of selected nodes. The Iceberg models under `models/iceberg/zendesk/` write through the catalog-linked database `dbt_iceberg_catalog_linked_db` (`catalogs.yml`), and three of them (`fct_tickets`, `zendesk_organizations`, `zendesk_tickets`) have no custom schema, so they fall through to `target.schema` — `ETLEAP_DBT_PR_XX`, uppercase. Snowflake rejects that in a catalog-linked database, and the failed listing aborts the whole run.

`zendesk_users.sql` sets `schema='zendesk'` explicitly, and that listing succeeded — which is the tell.

CI never hits this because `macros/generate_schema_name.sql` lowercases the schema when `target.name == 'ci'`. The `dev` target doesn't get that treatment.

## Change

Disables the Iceberg model directories so they leave the manifest. The cache warm-up no longer reaches the catalog-linked database:

```
1 of 1 OK created python table model ETLEAP_DBT_PR_XX.python_test_model [SUCCESS 1 in 5.51s]
```

## Reviewer note

This is a local-testing convenience, not a real fix — it turns off the `zendesk` Iceberg models for everyone. Consider whether that's acceptable on `main`, or whether this should stay a local-only change.

A lighter per-run alternative that needs no config change at all:

```
dbt run --select python_test_model --no-populate-cache
```

## On the durable fix

Lowercasing the schema for `dev` in `generate_schema_name` was tried and **reverted** — it is necessary but not sufficient. Probing the catalog-linked database directly:

| statement | result |
|---|---|
| `..."ETLEAP_DBT_PR_XX"` (quoted upper) | Invalid identifier |
| `...ETLEAP_DBT_PR_XX` (unquoted) | accepted (object doesn't exist) |
| `..."zendesk"` (quoted lower) | OK |

Quoted-uppercase is rejected outright, so the existing uppercase schema name cannot be kept. But lowercasing alone breaks the previously-working case: with `quoting: schema: true`, `"etleap_dbt_pr_xx"` and `"ETLEAP_DBT_PR_XX"` are distinct schemas, and dbt's schema-existence check is case-insensitive — it matches the uppercase one, skips `CREATE SCHEMA`, then writes to a lowercase schema that doesn't exist.

Closing that gap requires one of:

1. Create `TEST_ETLEAP."etleap_dbt_pr_xx"` once — keeps `quoting: true`, makes local match CI exactly.
2. Set `quoting.schema: false` — unquoted lowercase folds onto the existing uppercase schema in normal databases and stays lowercase in the catalog-linked one. Project-wide change.
3. Point the `dev` target at a fresh lowercase schema name — no uppercase twin, so dbt creates it automatically.

## Unrelated

`models/iceberg/models.yml` documents `tickets_from_iceberg_base`, which doesn't exist anywhere in `models/`. Source of the `Did not find matching node for patch` warning. Stale, harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
